### PR TITLE
Enable typechecking for configs

### DIFF
--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,5 +1,7 @@
-# typed: false
+# typed: true
 # Pin npm packages by running ./bin/importmap
+
+T.bind(self, Importmap::Map)
 
 pin "application", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,5 +1,7 @@
-# typed: false
+# typed: true
 # Puma configuration file.
+T.bind(self, Puma::DSL)
+
 max_threads_count = ENV.fetch("RAILS_MAX_THREADS") { 5 }
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count


### PR DESCRIPTION
We could have chosen to skip typechecking for the configuration files since are not part of the main application. But doing so can be helpful since configuration is often not covered by automated test, and it can catch accidental mistakes.

Both these configurations are DSLs, so we use `T.bind`.