### PR TITLE
Enable typechecking for helpers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,9 @@
 class ApplicationController < ActionController::Base
   include SessionsHelper
 
+  # These methods are called from views AND controllers
+  helper_method :remember, :current_user, :current_user?, :logged_in?
+
   private
 
     # Confirms a logged-in user.

--- a/app/controllers/sessions_helper.rb
+++ b/app/controllers/sessions_helper.rb
@@ -1,5 +1,7 @@
-# typed: false
+# typed: true
 module SessionsHelper
+  extend T::Helpers
+  requires_ancestor { ApplicationController }
 
   # Logs in the given user.
   def log_in(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,8 @@
-# typed: false
+# typed: true
+
 module UsersHelper
+  extend T::Helpers
+  requires_ancestor { ActionView::Base }
 
   # Returns the Gravatar for the given user.
   def gravatar_for(user, options = { size: 80 })

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,3 +1,4 @@
 --dir
 .
 --ignore=vendor/
+--enable-experimental-requires-ancestor

--- a/sorbet/rbi/dsl/account_activations_controller.rbi
+++ b/sorbet/rbi/dsl/account_activations_controller.rbi
@@ -23,9 +23,20 @@ class AccountActivationsController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
+
+    sig { returns(T.untyped) }
+    def current_user; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def current_user?(user); end
+
+    sig { returns(T.untyped) }
+    def logged_in?; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def remember(user); end
   end
 
   class HelperProxy < ::ActionView::Base

--- a/sorbet/rbi/dsl/application_controller.rbi
+++ b/sorbet/rbi/dsl/application_controller.rbi
@@ -26,9 +26,20 @@ class ApplicationController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
+
+    sig { returns(T.untyped) }
+    def current_user; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def current_user?(user); end
+
+    sig { returns(T.untyped) }
+    def logged_in?; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def remember(user); end
   end
 
   class HelperProxy < ::ActionView::Base

--- a/sorbet/rbi/dsl/microposts_controller.rbi
+++ b/sorbet/rbi/dsl/microposts_controller.rbi
@@ -23,9 +23,20 @@ class MicropostsController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
+
+    sig { returns(T.untyped) }
+    def current_user; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def current_user?(user); end
+
+    sig { returns(T.untyped) }
+    def logged_in?; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def remember(user); end
   end
 
   class HelperProxy < ::ActionView::Base

--- a/sorbet/rbi/dsl/password_resets_controller.rbi
+++ b/sorbet/rbi/dsl/password_resets_controller.rbi
@@ -23,9 +23,20 @@ class PasswordResetsController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
+
+    sig { returns(T.untyped) }
+    def current_user; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def current_user?(user); end
+
+    sig { returns(T.untyped) }
+    def logged_in?; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def remember(user); end
   end
 
   class HelperProxy < ::ActionView::Base

--- a/sorbet/rbi/dsl/rails/conductor/action_mailbox/inbound_emails/sources_controller.rbi
+++ b/sorbet/rbi/dsl/rails/conductor/action_mailbox/inbound_emails/sources_controller.rbi
@@ -23,7 +23,6 @@ class Rails::Conductor::ActionMailbox::InboundEmails::SourcesController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
   end

--- a/sorbet/rbi/dsl/rails/conductor/action_mailbox/inbound_emails_controller.rbi
+++ b/sorbet/rbi/dsl/rails/conductor/action_mailbox/inbound_emails_controller.rbi
@@ -23,7 +23,6 @@ class Rails::Conductor::ActionMailbox::InboundEmailsController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
   end

--- a/sorbet/rbi/dsl/rails/conductor/action_mailbox/incinerates_controller.rbi
+++ b/sorbet/rbi/dsl/rails/conductor/action_mailbox/incinerates_controller.rbi
@@ -23,7 +23,6 @@ class Rails::Conductor::ActionMailbox::IncineratesController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
   end

--- a/sorbet/rbi/dsl/rails/conductor/action_mailbox/reroutes_controller.rbi
+++ b/sorbet/rbi/dsl/rails/conductor/action_mailbox/reroutes_controller.rbi
@@ -23,7 +23,6 @@ class Rails::Conductor::ActionMailbox::ReroutesController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
   end

--- a/sorbet/rbi/dsl/rails/conductor/base_controller.rbi
+++ b/sorbet/rbi/dsl/rails/conductor/base_controller.rbi
@@ -26,7 +26,6 @@ class Rails::Conductor::BaseController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
   end

--- a/sorbet/rbi/dsl/relationships_controller.rbi
+++ b/sorbet/rbi/dsl/relationships_controller.rbi
@@ -23,9 +23,20 @@ class RelationshipsController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
+
+    sig { returns(T.untyped) }
+    def current_user; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def current_user?(user); end
+
+    sig { returns(T.untyped) }
+    def logged_in?; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def remember(user); end
   end
 
   class HelperProxy < ::ActionView::Base

--- a/sorbet/rbi/dsl/sessions_controller.rbi
+++ b/sorbet/rbi/dsl/sessions_controller.rbi
@@ -23,9 +23,20 @@ class SessionsController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
+
+    sig { returns(T.untyped) }
+    def current_user; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def current_user?(user); end
+
+    sig { returns(T.untyped) }
+    def logged_in?; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def remember(user); end
   end
 
   class HelperProxy < ::ActionView::Base

--- a/sorbet/rbi/dsl/static_pages_controller.rbi
+++ b/sorbet/rbi/dsl/static_pages_controller.rbi
@@ -23,9 +23,20 @@ class StaticPagesController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
+
+    sig { returns(T.untyped) }
+    def current_user; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def current_user?(user); end
+
+    sig { returns(T.untyped) }
+    def logged_in?; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def remember(user); end
   end
 
   class HelperProxy < ::ActionView::Base

--- a/sorbet/rbi/dsl/users_controller.rbi
+++ b/sorbet/rbi/dsl/users_controller.rbi
@@ -23,9 +23,20 @@ class UsersController
     include ::MicropostsHelper
     include ::PasswordResetsHelper
     include ::RelationshipsHelper
-    include ::SessionsHelper
     include ::StaticPagesHelper
     include ::UsersHelper
+
+    sig { returns(T.untyped) }
+    def current_user; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def current_user?(user); end
+
+    sig { returns(T.untyped) }
+    def logged_in?; end
+
+    sig { params(user: T.untyped).returns(T.untyped) }
+    def remember(user); end
   end
 
   class HelperProxy < ::ActionView::Base


### PR DESCRIPTION
We're now on to the trickiest part of enabling Sorbet for the app. This is partly a reflection of the complexity of how controllers, helpers and views interact in Rails.

We'll start by enabling the `--enable-experimental-requires-ancestor` option in Sorbet. Although this is described as 'experimental', it has been stable and reliable for a long time. It allows us to assist Sorbet understand typing by indicating the 'context' that a module is used in. In this case, these modules are view helpers.

Next, we need to deal with a slightly difficult design used in the tutorial. The app has a `SessionHelper` which contain methods used by the views. But this module is also included by the `ApplicationController`.

[explain why this is problematic]

I haven't read the tutorial's book for a long time, so I don't know if it explain why this approach was taken.

When you encounter situations like this, there are typically two general approaches:
* Work around the limitations of Sorbet, for example by using shims.
* Re-structure the code to make it easier for Sorbet to understand.

In this particular case