### PR TITLE
Enable typechecking for tests

### DIFF
--- a/sorbet/rbi/shims.rbi
+++ b/sorbet/rbi/shims.rbi
@@ -5,3 +5,11 @@ end
 class ActionController::MimeResponds::Collector
   include ::Turbo::StreamsHelper
 end
+
+class ActiveSupport::TestCase
+  include ActiveRecord::TestFixtures
+end
+
+class SessionsHelperTest < ActionView::TestCase
+  include SessionsHelper
+end

--- a/test/helpers/sessions_helper_test.rb
+++ b/test/helpers/sessions_helper_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 require "test_helper"
 
 class SessionsHelperTest < ActionView::TestCase

--- a/test/integration/users_index_test.rb
+++ b/test/integration/users_index_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 require "test_helper"
 
 class UsersIndexTest < ActionDispatch::IntegrationTest

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 require "test_helper"
 
 class UserMailerTest < ActionMailer::TestCase
@@ -6,7 +6,7 @@ class UserMailerTest < ActionMailer::TestCase
   test "account_activation" do
     user = users(:michael)
     user.activation_token = User.new_token
-    mail = UserMailer.account_activation(user)
+    mail = UserMailer.account_activation(user).message
     assert_equal "Account activation", mail.subject
     assert_equal [user.email], mail.to
     assert_equal ["user@realdomain.com"], mail.from
@@ -18,7 +18,7 @@ class UserMailerTest < ActionMailer::TestCase
   test "password_reset" do
     user = users(:michael)
     user.reset_token = User.new_token
-    mail = UserMailer.password_reset(user)
+    mail = UserMailer.password_reset(user).message
     assert_equal "Password reset", mail.subject
     assert_equal [user.email], mail.to
     assert_equal ["user@realdomain.com"], mail.from

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
-# typed: false
+# typed: true
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
@@ -12,11 +12,6 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
-
-  # Returns true if a test user is logged in.
-  def is_logged_in?
-    !session[:user_id].nil?
-  end
 end
 
 class ActionDispatch::IntegrationTest
@@ -26,5 +21,17 @@ class ActionDispatch::IntegrationTest
     post login_path, params: { session: { email: user.email,
                                           password: password,
                                           remember_me: remember_me } }
+  end
+
+  # Returns true if a test user is logged in.
+  def is_logged_in?
+    !session[:user_id].nil?
+  end
+end
+
+class ActionView::TestCase
+  # Returns true if a test user is logged in.
+  def is_logged_in?
+    !session[:user_id].nil?
   end
 end


### PR DESCRIPTION
The change to `is_logged_in` is interesting. This method was being called by two different kinds of tests, and for each of them `session` was referring to different things:

* In an `ActionView::TestCase`, `session` is a `ActionController::TestSession`.
* In an `ActionDispatch::IntegrationTest`, `session` is a `ActionDispatch::Request::Session`.

TODO: Explain `ActionMailer::MessageDelivery` vs `Mail::Message`